### PR TITLE
Fix quote typo

### DIFF
--- a/toolbox-tramp.el
+++ b/toolbox-tramp.el
@@ -75,7 +75,7 @@
                  (tramp-remote-shell       "/bin/sh")
                  (tramp-remote-shell-args  ("-i" "-c")))))
 
-(add-to-list 'tramp-default-host-alist '(,toolbox-tramp-method nil ""))
+(add-to-list 'tramp-default-host-alist `(,toolbox-tramp-method nil ""))
 
 ;;;###autoload
 (eval-after-load 'tramp


### PR DESCRIPTION
The typo was causing the following error when using TRAMP:

```
Error in post-command-hook (vertico--exhibit): (wrong-type-argument stringp (\, toolbox-tramp-method))
```