### PR TITLE
Change select container string

### DIFF
--- a/toolbox-mode.el
+++ b/toolbox-mode.el
@@ -31,7 +31,7 @@
 
 (defun toolbox-select-container (container)
   (interactive
-   (list (completing-read "Which Container:" (toolbox-tramp-toolbox-containers))))
+   (list (completing-read "Select container: " (toolbox-tramp-toolbox-containers))))
   (setq toolbox-connected-container container)
   (toolbox-tramp-reopen-file-in-toolbox (current-buffer) container))
 

--- a/toolbox-tramp.el
+++ b/toolbox-tramp.el
@@ -83,7 +83,7 @@ FILENAME is ignored as this it is sourced from podman"
 (defun toolbox-tramp-start-toolbox (container)
   "Start a toolbox CONTAINER for later connection."
   (interactive
-   (list (completing-read "Which Container" (toolbox-tramp-stopped-toolbox-containers))))
+   (list (completing-read "Select container: " (toolbox-tramp-stopped-toolbox-containers))))
     (let ((args . ((append `(,toolbox-tramp-executable "container" "start")))))
       (apply 'call-process (append (list (car args) nil nil nil) (cdr args) (list container)))))
 
@@ -101,7 +101,7 @@ FILENAME is ignored as this it is sourced from podman"
 This also allows for changing current container."
   (interactive (list
 		(read-buffer "Buffer: " (current-buffer) t)
-		(completing-read "Which Container" (toolbox-tramp-toolbox-containers))))
+		(completing-read "Select container: " (toolbox-tramp-toolbox-containers))))
   (find-alternate-file (toolbox-tramp--path-for-buffer
 			(buffer-file-name (get-buffer buffer))
 			 container)))


### PR DESCRIPTION
I noticed the same string wasn't used in different scenarios when selecting a container. Also, the tone (question vs prompt) and capitalization didn't match that of other Emacs features (“Find file: ”, “Switch to: ”).

I changed the string from a question (“which container”) to a prompt (“select container”), and changed capitalization. All strings are now read “Select container: ”, with a space after.